### PR TITLE
Update documentation for Unknown Entity Monitoring Ticket

### DIFF
--- a/docs/data-operations-manual/How-To-Guides/Maintaining/Assign-entities.md
+++ b/docs/data-operations-manual/How-To-Guides/Maintaining/Assign-entities.md
@@ -29,20 +29,3 @@ digital-land assign-entities collection/tree-preservation-order/resource/4e0de67
 
 3. **Check results**  
    Confirm the desired result in the lookup.csv file, the amount of entities that needed to be assigned should be the same amount that have been added in the lookup file.
-
-## Batch assigning entities
-
-1. **Download issue summary table**
-   Get the issue summay table from the [config-manager for ODP data](https://config-manager-prototype.herokuapp.com/reporting/odp-summary/issue) by clicking the `Download Current Table`
-
-2. **Add the file to the root of config**  
-   The downloaded file is called `odp-issue.csv`, don't change the file extension! Copy it over from the downloaded location to the root of `config` where the script `batch_assign_entities.py` is located.
-
-3. **Run the script**  
-   The script can be run using the command `python3 batch_assign_entities.py [PATH_TO_FILE]` so with the above moved file location the command would be `python3 batch_assign_entities.py odp-issue.csv`
-
-4. **Populated lookup**
-   It will download all the resources for unknown entities into a `resources` folder, assign entities, and then delete the downloaded resource files. The affected dataset's `lookup.csv` should now have new rows with the assigned entities. The amount of entities that needed to be assigned should be the same amount that have been added in the lookup file.
-
-5. **Check config-manager issue summary**
-   After the changes have been merged and collected by the workflows and datasette, check [config-manager for ODP data](https://config-manager-prototype.herokuapp.com/reporting/odp-summary/issue) and download the table again. There should be no unknown entities anymore (unless the collector has found new data but the entities from before assigning entities should be gone)

--- a/docs/data-operations-manual/Tutorials/Monitoring-Data-Quality.md
+++ b/docs/data-operations-manual/Tutorials/Monitoring-Data-Quality.md
@@ -7,16 +7,54 @@ This section covers situations where we are monitoring the quality of data and f
 To keep the datasets up-to-date on the platform, we need to check “unknown entity” issues every week and assign entities.
 The unknown entities issue usually occurs when an LPA updates their data on the endpoint we are retrieving and adds new records. These records will have reference values we do not have on the platform, hence when the system realises the new data has been added and the references of those new data are not on the platform, it will trigger an unknown entity issue.
 
+The datasets that require assigning entities are categorised into three main scopes:
+
+ODP Datasets – These datasets are supported by ODP funding. Datasets categorised as ODP can be found here [ODP Data](https://datasette.planning.data.gov.uk/digital-land?sql=select+rowid%2C+dataset%2C+cohort%2C+notes%2C+project%2C+provision_rule%2C+role%2C+specification+from+provision+where+%22project%22+%3D+%3Ap0+group+by+dataset&p0=open-digital-planning)
+
+Mandated Datasets – These are datasets that LPAs are legally required to provide, this includes brownfield-land and developer-contributions datasets.
+
+Single Source Datasets – This category includes data obtained from authoritative sources or seeded data received from the Data Design Team.
+
 The recommended steps to resolve this are as follows:
 
-1. Go to the report found [here](https://config-manager-prototype.herokuapp.com/reporting/odp-summary/issue)
-2. Download the CSV file with ‘Download Current Table’ which will download a file called `odp_issues`
-3. Analyse the "unknown entity" issues. Look for `issue_type` with `unknown entity`
-4. If possible, for each of the issues you have identified, follow the steps in [Assign entities](../../How-To-Guides/Maintaining/Assign-entities). Keep track of the row of the issue.
-5. Raise a PR and merge it
-6. Once merged, run the issue report again and check if the previous unknown entity is resolved. Paste the row of “unknown entity” issues you have tracked in [this google docs](https://docs.google.com/spreadsheets/d/1gZ_SIx9jdko_aD3QRZUJh39PdNHISS1N/edit?usp=drive_link&ouid=105995804157199974210&rtpof=true&sd=true) after the changes are merged on the platform.
-7. Note in the sheet if you are not able to assign entities for any LPA
-8. Insert a new workbook with the next sprint date
+1. **Setup Config Repo**
+    Clone the [Config repository](https://github.com/digital-land/config) if it has not already been done, then create and activate a virtual environment.
+
+2. **Run the Script**
+    The script can be run using the command `python3 batch_assign_entities.py`
+
+    Upon execution, the script will download the `issue_summary.csv` file to the root directory of the Config folder.
+
+    The downloaded `issue_summary.csv` includes a column called scope, this column indicates the scope for each dataset. This scope includes the categories specified above, such as ODP, Mandated and Single source.
+
+3. **Analyse Unknown Entity issues**
+    Open the `issue_summary.csv` file and apply a filter to the "scope" column to display only entries related to ODP. Begin by analysing all unknown entities issues associated with the ODP scope.
+
+    If the `count_issue` for any dataset is unusually high, verify that the entities are valid and new. `count_issue` may also be high if the LPA has recently their references for existing entities.
+
+    The command will prompt the user to confirm. Type "yes" to assign Unknown entities for ODP.
+
+    The command will prompt the user to enter scope (odp/mandated/single-source). Type "odp" to assign entities. 
+    
+    It will download all the resources for unknown entities into a resources folder, assign entities, and then delete the downloaded resource files. The affected dataset’s lookup.csv should now have new rows with the assigned entities. The amount of entities that needed to be assigned should be the same amount that have been added in the lookup file.
+
+    Unknown entities will be automatically assigned.
+
+4. **Assign entities for Mandated and single-source datasets**
+    Repeat Step 3 for assign entities for Mandated and single-source datasets.
+
+    Enter the scope, either mandated or single-source based on requirement.
+    
+5. **Merge Changes**
+    Raise a PR and merge it after it's reviewed.
+
+    Create a new sheet in [this google docs](https://docs.google.com/spreadsheets/d/1gZ_SIx9jdko_aD3QRZUJh39PdNHISS1N/edit?usp=drive_link&ouid=105995804157199974210&rtpof=true&sd=true) and rename the sheet to have the Sprint start date.
+    Paste the row of “unknown entity” issues you have resolved in the google sheet, This will help track the datasets you've updated and ensure they are noted for future review.
+
+6. **Review Changes**
+    Once merged, use [endpoint_dataset_issue_type_summary table](https://datasette.planning.data.gov.uk/performance/endpoint_dataset_issue_type_summary?_sort=rowid&issue_type__exact=unknown+entity) and check if the previous unknown entity issues are resolved. 
+    
+    Note in the sheet if you are not able to assign entities for any LPA.
 
 Success criteria:
 Ideally, the number of unknown entity errors should be zero after completing the above steps.

--- a/docs/data-operations-manual/Tutorials/Monitoring-Data-Quality.md
+++ b/docs/data-operations-manual/Tutorials/Monitoring-Data-Quality.md
@@ -30,7 +30,7 @@ The recommended steps to resolve this are as follows:
 3. **Analyse Unknown Entity issues**
     Open the `issue_summary.csv` file and apply a filter to the "scope" column to display only entries related to ODP. Begin by analysing all unknown entities issues associated with the ODP scope.
 
-    If the `count_issue` for any dataset is unusually high, verify that the entities are valid and new. `count_issue` may also be high if the LPA has recently their references for existing entities.
+    If the `count_issue` for any dataset is unusually high, verify that the entities are valid and new. `count_issue` may also be high if the LPA has recently their references for existing entities. Keep a note of endpoints with an unusually high number of `count_issue` to review once the entities have been assigned.
 
     The command will prompt the user to confirm. Type "yes" to assign Unknown entities for ODP.
 
@@ -39,6 +39,10 @@ The recommended steps to resolve this are as follows:
     It will download all the resources for unknown entities into a resources folder, assign entities, and then delete the downloaded resource files. The affected dataset’s lookup.csv should now have new rows with the assigned entities. The amount of entities that needed to be assigned should be the same amount that have been added in the lookup file.
 
     Unknown entities will be automatically assigned.
+
+    Review the entities assigned for the endpoint you’ve noted. The key thing to check here is whether the references are a continuation or follow a similar format to existing lookups for that provision.
+
+    Note: If the entities belong to the Conservation Area dataset, you should check for duplicates using endpoint checker, refer Step 3 in [Validating an endpoint](https://digital-land.github.io/technical-documentation/data-operations-manual/How-To-Guides/Validating/Validate-an-endpoint/). Once the new entries for the lookup.csv have been generated, use the outputs from the `Duplicates with different entity numbers` section of the endpoint checker to replace the newly generated entity numbers for any duplicates, with the entity numbers of the existing entity that they match.
 
 4. **Assign entities for Mandated and single-source datasets**
     Repeat Step 3 for assign entities for Mandated and single-source datasets.


### PR DESCRIPTION
Updated the approach to include a "Scope" column in the downloaded issue summary, allowing scope like ODP, mandated and single-source datasets to be added in segments rather than all at once.

![image](https://github.com/user-attachments/assets/fe622330-efb6-4b08-a2b9-6066cd44169b)
