### PR TITLE
Add Docker Desktop installation instructions to Mac setup guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ build/
 # Ignore cache
 .sass-cache
 .cache
-
+.history
 # Ignore .DS_store file
 .DS_Store
 

--- a/docs/development/tutorials/set-up-for-mac.md
+++ b/docs/development/tutorials/set-up-for-mac.md
@@ -13,6 +13,7 @@ Contents:
 * Install Make
 * Install sqlite3
 * Install Python (and understand venvs)
+* Install Docker Desktop
 * Set up SSH for Github
 * Optional but recommended setup
 
@@ -205,6 +206,47 @@ workon
 You see in the aliases above that workon is used in the mkvirtualenv aliases to automatically activate a venv after creating one
 
 > Tip: If you're using more versions of Python the aliases above can easily be edited to different versions by simply changing the version of Python which is being called
+
+### Install Docker Desktop
+
+Some of our repositories use Docker to run supporting services locally or to run tests with tools such as Testcontainers. On Mac, the simplest way to get Docker running is to install Docker Desktop.
+
+Before installing, check whether your Mac uses Apple silicon or an Intel chip:
+
+```sh
+uname -m
+```
+
+If this returns `arm64`, use the Apple silicon download. If it returns `x86_64`, use the Intel download.
+
+Go to the official Docker install page and download Docker Desktop for the correct chip:
+
+* https://docs.docker.com/desktop/setup/install/mac-install/
+
+Then install it:
+
+1. Open the downloaded `Docker.dmg` file.
+2. Drag Docker into the `Applications` folder.
+3. Open Docker from `Applications`.
+4. Accept the Docker Desktop terms if they apply to your use.
+5. Choose the recommended settings when prompted.
+6. Enter your Mac password if Docker asks for permission to finish setup.
+
+
+Once Docker Desktop has started, check that the command line tools are available:
+
+```sh
+docker --version
+docker compose version
+```
+
+You can also run a small test container:
+
+```sh
+docker run hello-world
+```
+
+If the test works, Docker is ready to use. Docker Desktop needs to be running in the background whenever you run commands such as `docker build`, `docker compose up`, or tests that start containers.
 
 ### Set up SSH for Github
 

--- a/docs/development/tutorials/set-up-for-mac.md
+++ b/docs/development/tutorials/set-up-for-mac.md
@@ -211,7 +211,17 @@ You see in the aliases above that workon is used in the mkvirtualenv aliases to 
 
 Some of our repositories use Docker to run supporting services locally or to run tests with tools such as Testcontainers. On Mac, the simplest way to get Docker running is to install Docker Desktop.
 
-Before installing, check whether your Mac uses Apple silicon or an Intel chip:
+There are two ways to install Docker Desktop:
+
+* Install it using Homebrew, if you already have Homebrew installed:
+
+```sh
+brew install --cask docker-desktop
+```
+
+* Download it from the Docker website.
+
+Before downloading Docker Desktop from the Docker website, check whether your Mac uses Apple silicon or an Intel chip:
 
 ```sh
 uname -m


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Adds instructions for installing Docker Desktop on macOS to the Mac setup tutorial, including how to check Mac chip architecture, choose the correct Docker Desktop download, complete installation, and verify Docker is working from the command line.

## Related Tickets & Documents

- Ticket Link: N/A
- Related Issue #: N/A
- Closes #: N/A

## QA Instructions, Screenshots, Recordings

Checked the updated documentation page builds successfully.

QA steps performed:

```sh
npm run build
```

The Eleventy build completed successfully. Existing Sass/GOV.UK deprecation warnings were shown, but there were no build errors.

No screenshots or recordings are needed because this is a documentation-only change.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: this is a documentation-only change. The site build was run to verify the markdown renders successfully.
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

None.

## [optional] Are there any dependencies on other PRs or Work?

None.