### PR TITLE
feat: Add health endpoint guidelines for status monitoring and enhanc…

### DIFF
--- a/docs/architecture-and-infrastructure/alerting-and-monitoring.md
+++ b/docs/architecture-and-infrastructure/alerting-and-monitoring.md
@@ -33,6 +33,7 @@ Our monitoring and alerting aims to:
 ### ✅ Availability and Health
 
 - Health checks for public endpoints
+- Service health checks should include critical dependencies so a service can report as degraded when it is reachable but cannot perform its core function
 - Alerts for incidents affecting production (AWS alarms, Airfow alerts)
 - Application health metrics
 - Aiflow health metrics
@@ -113,5 +114,4 @@ Dashboards are reviewed regularly for completeness and accuracy.
 - [GDS Monitoring Guide](https://www.gov.uk/service-manual/technology/monitoring-your-service)
 - [Sentry Documentation](https://docs.sentry.io/)
 - [AWS CloudWatch Documentation](https://docs.aws.amazon.com/cloudwatch/)
-
 

--- a/docs/development/monitoring.md
+++ b/docs/development/monitoring.md
@@ -6,6 +6,65 @@ Across our infrastructure we host multiple applications and data pipelines all u
 
 We're still developing and improving our approach to monitoring so please reach out with any new ideas or improvements!
 
+### Status monitoring
+
+Public services should expose a `/health` endpoint that can be used by our status monitoring. The endpoint should do more than confirm that the web application can return a response. It should report whether the service can perform its core user-facing function.
+
+Critical dependencies should contribute to the health response. For example, if a service depends on Redis, Datasette, a database, or another internal API to serve users, the health check should include that dependency. A service should not report as fully healthy when a critical dependency is unavailable.
+
+The recommended pattern is:
+
+* return `200` when the health endpoint itself is reachable
+* include a JSON health payload with a `status` value
+* report `healthy` when the service and its critical dependencies are working
+* report `degraded` when the service is reachable but a critical dependency or important capability is not working
+* report an error response only when the health endpoint itself cannot run
+
+For example, a healthy response should look like:
+
+```json
+{
+  "status": "healthy",
+  "checks": {
+    "redis": "healthy",
+    "datasette": "healthy"
+  }
+}
+```
+
+A degraded response should still make clear which dependency is causing the degraded state:
+
+```json
+{
+  "status": "degraded",
+  "checks": {
+    "redis": "healthy",
+    "datasette": "unavailable"
+  }
+}
+```
+
+Our status monitoring platform is [UpptimeJS](https://upptime.js.org/). The configuration is held in the [digital-land/service-status](https://github.com/digital-land/service-status) repository.
+
+Status monitoring should check the health endpoint and interpret the payload, not only the HTTP status code. Configure the service in `.upptimerc.yml` so UpptimeJS:
+
+* calls the service `/health` endpoint
+* expects the health endpoint to return `200`
+* marks the service as down if the response does not include a health status payload
+* marks the service as degraded if the payload reports `{"status":"degraded"`
+
+For example:
+
+```yaml
+sites:
+  - name: Provide
+    url: https://provide.planning.data.gov.uk/health
+    expectedStatusCodes:
+      - 200
+    __dangerous__body_down_if_text_missing: '{"status":'
+    __dangerous__body_degraded: '{"status":"degraded"'
+```
+
 ### Slack notifications
 
 The most useful tool at our disposable is the delivery of key notifications in our Slack notifications channel. If you are not part of this reach out to the tech ead to get access. There are several key types of notifications:

--- a/docs/search-index.json.njk
+++ b/docs/search-index.json.njk
@@ -14,6 +14,6 @@ layout: false
     "headings": {{ item.templateContent | searchHeadings | dump | safe }},
     "content": {{ item.templateContent | searchContent | dump | safe }},
     "templateContent": {{ item.templateContent | tokenize | dump | safe }},
-    "url": {{ item.url | canonicalUrl | pretty | dump | safe }}
+    "url": {{ item.url | prefixUrl | pretty | dump | safe }}
   }{% if not loop.last %},{% endif %}
 {% endfor %}]

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -31,6 +31,14 @@ function searchHeadings(html) {
         .filter(Boolean);
 }
 
+function prefixUrl(url, pathPrefix) {
+    if (!url || pathPrefix === '/' || URL.canParse(url)) {
+        return url;
+    }
+
+    return `${pathPrefix.replace(/\/$/, '')}${url}`;
+}
+
 module.exports = function(eleventyConfig) {
     const pathPrefix = process.env.GITHUB_ACTIONS ? '/technical-documentation/' : '/'
 
@@ -63,6 +71,9 @@ module.exports = function(eleventyConfig) {
     eleventyConfig.setQuietMode(false)
     eleventyConfig.addFilter('searchContent', searchContent);
     eleventyConfig.addFilter('searchHeadings', searchHeadings);
+    eleventyConfig.addFilter('prefixUrl', function(url) {
+        return prefixUrl(url, pathPrefix);
+    });
     eleventyConfig.addGlobalData("layout", "base.njk");
     eleventyConfig.addPassthroughCopy("assets")
     eleventyConfig.addPassthroughCopy("images");


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [x] Documentation Update

## Description

Adds guidance for service status monitoring and health endpoint behaviour. The documentation now recommends that public services expose a `/health` endpoint, include critical dependencies in the health response, and report a degraded status when the service is reachable but cannot perform its core function.

This also fixes generated search URLs for the GitHub Pages deployment by prefixing search index paths and search result URLs with `/technical-documentation/`.

## Related Tickets & Documents

- Ticket Link
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

Built the documentation site locally:

```bash
npm run build
```

Confirmed the generated search component points to `/technical-documentation/search-index.json` and search result URLs are prefixed with `/technical-documentation/`.

No screenshots included because this is a documentation and generated URL fix.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: this is a static documentation update and Eleventy configuration/template change. It was validated by building the site locally.
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

After deployment, check the documentation search on GitHub Pages and confirm search results navigate without 404s.

## [optional] Are there any dependencies on other PRs or Work?

None.